### PR TITLE
Add a build script and update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,5 @@
 # Deploying
 This repo automatically publishes to NPM when PRs are merged to main.
 
-After a PR is merged, go to /actions and once the publish workflow is complete, grab the new version number to update other repos with.
-
 # Contributing
 Right now, contributions to this library are done under https://github.com/Expensify/App. Please refer to that repo and all it's guidelines for contributing.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# react-native-x-maps
+# `react-native-x-maps`
+
+# Deploying
+This repo automatically publishes to NPM when PRs are merged to main.
+
+After a PR is merged, go to /actions and once the publish workflow is complete, grab the new version number to update other repos with.
+
+# Contributing
+Right now, contributions to this library are done under https://github.com/Expensify/App. Please refer to that repo and all it's guidelines for contributing.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "A cross platform compatible map component for React-Native",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "echo \"Warning: no build process has been specified yet\"",
     "lint": "eslint index.js",
     "prettier": "prettier --write .",
-    "prettier-watch": "onchange \"**/*.js\" -- prettier --write --ignore-unknown {{changed}}"
+    "prettier-watch": "onchange \"**/*.js\" -- prettier --write --ignore-unknown {{changed}}",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The missing build script is causing the "publish to NPM" workflow to fail. For now, this adds a placeholder build script.

### Manual Tests
1. Once this PR is merged, go to the "Actions" tab in GH
2. Verify that the publish workflow completes without error
3. Search NPMjs.org and verify the package was published
