### PR TITLE
Fix the `build` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
         "src"
     ],
     "scripts": {
-        "build": "rm -rf dist && npm run ts:declarations && npx babel src --out-dir dist --extensions '.ts,.tsx'",
+        "build": "rm -rf dist && npx tsc --emitDeclarationOnly && npx babel src --out-dir dist --extensions '.ts,.tsx'",
         "lint": "eslint src --fix",
         "ts": "npx tsc --noEmit",
-        "ts:declarations": "npx tsc --emitDeclarationOnly",
         "prettier": "prettier --write .",
         "prettier-watch": "onchange \"**/*.js\" -- prettier --write --ignore-unknown {{changed}}",
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
         "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
         "declarationMap": true /* Create sourcemaps for d.ts files. */,
         "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-        "noEmit": true /* Disable emitting files from a compilation. */,
         "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
         "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
         "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,


### PR DESCRIPTION
cc: @tgolen 

### Related Issues

GH_LINK: https://github.com/Expensify/react-native-x-maps/issues/12

This PR fixes the `build` command specified in `package.json`.

### Problem
The ["Publish package to npmjs"]((https://github.com/Expensify/react-native-x-maps/blob/main/.github/workflows/publish.yml)) workflow failed [here](https://github.com/Expensify/react-native-x-maps/actions/runs/5744414406) because of the incompatibility between a TypeScript configuration and an option passed to the TypeScript compiler.

Specifically, the following configuration and option conflicted with each other.

`tsconfig.json`: `"noEmit": true`
`package.json`: `npx tsc --emitDeclarationOnly`

During the build, `--emitDeclarationOnly` instructs `tsc` (TypeScript compiler) to generate only `d.ts` files.

_If you're curious, the actual compilation is handled by babel_

However, the `noEmit` option, which is turned on in `tsconfig.json`, tells `tsc` to not to generate anything at all, conflicting with the above `emitDeclarationOnly` option.

### Fix

Removes `"noEmit": true` from `tsconfig.json`. This is safe because the `ts` command in `package.json`, which is used to type-check, already passes `--noEmit` option.

### Cleanup

Removes the `ts:declarations` command from `package.json` and directly run the `tsc` command inside the `build` command.

### Test

Run `npm run build` in the project root directory. Confirm that the command runs without an error and the `dist` folder is created.
