### PR TITLE
Make map bound calculations simpler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
                 "typescript": "^5.1.6"
             },
             "peerDependencies": {
-                "@math.gl/web-mercator": "^3.6.3",
                 "@rnmapbox/maps": "^10.0.11",
                 "mapbox-gl": "^2.15.0",
                 "react": "^18.2.0",
@@ -2609,16 +2608,6 @@
                 "gl-style-format": "dist/gl-style-format.mjs",
                 "gl-style-migrate": "dist/gl-style-migrate.mjs",
                 "gl-style-validate": "dist/gl-style-validate.mjs"
-            }
-        },
-        "node_modules/@math.gl/web-mercator": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
-            "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.12.0",
-                "gl-matrix": "^3.4.0"
             }
         },
         "node_modules/@nicolo-ribaudo/chokidar-2": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     },
     "homepage": "https://github.com/Expensify/react-native-x-maps#readme",
     "peerDependencies": {
-        "@math.gl/web-mercator": "^3.6.3",
         "@rnmapbox/maps": "^10.0.11",
         "mapbox-gl": "^2.15.0",
         "react": "^18.2.0",

--- a/src/MapView/MapView.web.tsx
+++ b/src/MapView/MapView.web.tsx
@@ -1,31 +1,14 @@
 import Map, {MapRef, Marker} from 'react-map-gl';
 import {forwardRef, useCallback, useEffect, useImperativeHandle, useState} from 'react';
-import WebMercatorViewport from '@math.gl/web-mercator';
 import {View} from 'react-native';
-import {MapViewHandle, MapViewProps, WayPoint} from './MapViewTypes';
+import {MapViewHandle, MapViewProps} from './MapViewTypes';
 import Utils from './utils';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import Direction from './Direction';
 import {DEFAULT_INITIAL_STATE} from './CONST';
 
-const getAdjustment = (mapRef: MapRef, waypoints: WayPoint[], mapPadding?: number) => {
-    const {clientHeight, clientWidth} = mapRef.getCanvas();
-    const viewport = new WebMercatorViewport({height: clientHeight, width: clientWidth});
-
-    const {northEast, southWest} = Utils.getBounds(waypoints.map((waypoint) => waypoint.coordinate));
-    return viewport.fitBounds([southWest, northEast], {
-        padding: mapPadding,
-    });
-};
-
 const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView({accessToken, waypoints, style, mapPadding, directionCoordinates, initialState = DEFAULT_INITIAL_STATE}, ref) {
-    // const mapRef = useRef<MapRef>(null);
     const [mapRef, setMapRef] = useState<MapRef | null>(null);
-    const [bounds, setBounds] = useState<{
-        longitude: number;
-        latitude: number;
-        zoom: number;
-    }>();
 
     const setRef = useCallback((newRef: MapRef | null) => setMapRef(newRef), []);
 
@@ -46,8 +29,10 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView({access
             return;
         }
 
-        const newBounds = getAdjustment(mapRef, waypoints, mapPadding);
-        setBounds(newBounds);
+        const map = mapRef.getMap();
+
+        const {northEast, southWest} = Utils.getBounds(waypoints.map((waypoint) => waypoint.coordinate));
+        map.fitBounds([northEast, southWest], {padding: mapPadding});
     }, [waypoints, mapRef]);
 
     useImperativeHandle(
@@ -73,7 +58,6 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView({access
                     zoom: initialState?.zoom,
                 }}
                 mapStyle="mapbox://styles/mapbox/streets-v9"
-                {...bounds}
             >
                 {waypoints &&
                     waypoints.map(({coordinate, markerComponent: MarkerComponent}) => (

--- a/src/MapView/MapViewTypes.ts
+++ b/src/MapView/MapViewTypes.ts
@@ -37,13 +37,13 @@ type InitialState = {
 };
 
 // Waypoint to be displayed on the map
-type WayPoint = {
+export type WayPoint = {
     coordinate: [number, number];
     markerComponent: ComponentType;
 };
 
 // Style used for the line that displays direction
-type DirectionStyle = {
+export type DirectionStyle = {
     width?: number;
     color?: string;
 };


### PR DESCRIPTION
cc: @neil-marcellini @thienlnam 

### Terminology
- `Map`: A component from `react-map-gl` that `react-native-x-maps` uses under the hood for web code.
- `MapView`: A component that `react-native-x-maps` implements and is used by NewDot.

### Details

_This PR not the exposed API of `MapView`. This PR fixes an issue that was present with previous version of the code._

Use a simpler API from `react-map-gl` and `mapbox-gl` to pan the map in order to fit all waypoints within the visible area. The `fitBounds` method on the map instance is called to pan the map. The map instance is returned by invoking `getMap` method on  `Map`.

The previous code stored the ref to `Map` with `useRef`. However, I realized that `mapRef` is sometimes not set when the `getMap` method is invoked on it. So, instead of using `useRef`, I decided to use `useState` and the [callback ref](https://react.dev/reference/react-dom/components/common#ref-callback) to store the reference to `Map`.

In the `useEffect` where I pan the map, I added `mapRef` as a dependency. Because `mapRef` is a state, if `mapRef`'s value changes (i.e. `null` -> reference to `Map`), the `MapView` re-renders, triggering `useEffect` and panning the map if conditions are met.

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

GH_LINK https://github.com/Expensify/App/issues/22706

### Manual Tests

This PR is tested in [this App PR](https://github.com/Expensify/App/pull/25161). [This test branch/PR in react-native-x-maps](https://github.com/Expensify/react-native-x-maps/pull/24) is used for testing in the App PR. The test branch is a clone of this PR but it also includes the transpiled code. If the test branch works in App, that means this PR is good to go. If this PR is merged, the code is transpiled in CI and a new version of npm package is published.

### Linked PRs

https://github.com/Expensify/App/pull/25161
