### PR TITLE
Pass down directionStyle prop down

### DIFF
--- a/src/MapView/MapView.web.tsx
+++ b/src/MapView/MapView.web.tsx
@@ -8,7 +8,7 @@ import Direction from './Direction';
 import {DEFAULT_INITIAL_STATE} from './CONST';
 
 const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
-    {accessToken, waypoints, style, mapPadding, directionCoordinates, initialState = DEFAULT_INITIAL_STATE, styleURL},
+    {accessToken, waypoints, style, mapPadding, directionCoordinates, initialState = DEFAULT_INITIAL_STATE, styleURL, directionStyle},
     ref,
 ) {
     const [mapRef, setMapRef] = useState<MapRef | null>(null);
@@ -72,7 +72,12 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
                             <MarkerComponent />
                         </Marker>
                     ))}
-                {directionCoordinates && <Direction coordinates={directionCoordinates} />}
+                {directionCoordinates && (
+                    <Direction
+                        coordinates={directionCoordinates}
+                        directionStyle={directionStyle}
+                    />
+                )}
             </Map>
         </View>
     );


### PR DESCRIPTION
@thienlnam 

### Details

I forgot to pass down `directionStyle` prop to `Direction` component in `MapView.web.tsx`.

### Related Issues

Slack convo: https://expensify.slack.com/archives/C05DWUDHVK7/p1692662708267799?thread_ts=1692653449.969119&cid=C05DWUDHVK7

### Manual Tests
Testing takes time (I need to create a separate branch where I commit transpiled code, and pull that branch in `package.json` on another test branch in `App`). So... I suggest we just merge this and test this in @thienlnam's [App PR](https://github.com/Expensify/App/pull/25434) 🙇 

### Linked PRs

- https://github.com/Expensify/App/pull/25434