### PR TITLE
Fix Map Panning issue

### DIFF
--- a/src/MapView/MapView.tsx
+++ b/src/MapView/MapView.tsx
@@ -39,7 +39,7 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
         [],
     );
 
-    const onMapIdle = (e: MapState) => {
+    const setMapIdle = (e: MapState) => {
         if (e.gestures.isGestureActive) return;
         setIsIdle(true);
     }
@@ -55,7 +55,7 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
                 styleURL={styleURL}
                 pitchEnabled={pitchEnabled}
                 style={{flex: 1}}
-                onMapIdle={onMapIdle}
+                onMapIdle={setMapIdle}
             >
                 <Mapbox.Camera
                     ref={cameraRef}

--- a/src/MapView/MapView.tsx
+++ b/src/MapView/MapView.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useEffect, useImperativeHandle, useCallback, useRef, useState} from 'react';
+import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import Mapbox, {MapState, MarkerView} from '@rnmapbox/maps';
 import {View} from 'react-native';
 import {MapViewProps, MapViewHandle} from './MapViewTypes';

--- a/src/MapView/MapView.web.tsx
+++ b/src/MapView/MapView.web.tsx
@@ -7,7 +7,7 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import Direction from './Direction';
 import {DEFAULT_INITIAL_STATE} from './CONST';
 
-const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
+const MapView = forwardRef<MapViewHandle, Omit<MapViewProps, "isFocused">>(function MapView(
     {accessToken, waypoints, style, mapPadding, directionCoordinates, initialState = DEFAULT_INITIAL_STATE, styleURL, directionStyle},
     ref,
 ) {

--- a/src/MapView/MapViewTypes.ts
+++ b/src/MapView/MapViewTypes.ts
@@ -6,6 +6,8 @@ export type MapViewProps = {
     accessToken: string;
     // Style applied to MapView component. Note some of the View Style props are not available on ViewMap
     style: StyleProp<ViewStyle>;
+    // Focus state of the screen
+    isFocused: boolean
     // Link to the style JSON document.
     styleURL?: string;
     // Whether map can tilt in the vertical direction.


### PR DESCRIPTION

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

- Added isFocused property.
- Added isIdle state
- Incorrectly used useMemo replaced with useEffect.
- Added new props to avoid introducing unnecessary dependencies ('@react-navigation/native') to the 'react-native-x-maps' library.

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/25732

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Click the "+" icon next to the chat message text field. Click "Request Money" on the pop up menu that appears.
2. Check "Distance" tab on the Right Hand Panel that appears
3. Click the "Start" item from the list of waypoints.
4. In the text field that appears in the next screen, type "88 Kearny Street". Click the first option "88 Kearny Street, San Francisco, CA, USA" that appears.
5. Map camera flied to selected address where marker is visible.
6. Click Add Step button
7. Click on new added step
8. In the text field that appears in the next screen, type "Golden Gate Park". Click the first option "Golden Gate Pkwy, Naples, FL, USA" that appears.
9. Verify that the 2 markers are on the map and camera moved to show both on the screen.
10. Added Finish step
11. Verify that the distance was drawn as expected.

### Linked PRs
https://github.com/Expensify/App/pull/25977
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
