### PR TITLE
Fix react duplicate keys

### DIFF
--- a/src/MapView/MapView.tsx
+++ b/src/MapView/MapView.tsx
@@ -63,10 +63,10 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
                     bounds={bounds}
                 />
                 {waypoints &&
-                    waypoints.map(({coordinate, markerComponent: MarkerComponent}) => (
+                    waypoints.map(({coordinate, markerComponent: MarkerComponent}, index) => (
                         <MarkerView
                             id={`${coordinate[0]},${coordinate[1]}`}
-                            key={`${coordinate[0]},${coordinate[1]}`}
+                            key={`${index},${coordinate[0]},${coordinate[1]}`}
                             coordinate={coordinate}
                         >
                             <MarkerComponent />

--- a/src/MapView/MapView.web.tsx
+++ b/src/MapView/MapView.web.tsx
@@ -63,9 +63,9 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
                 mapStyle={styleURL}
             >
                 {waypoints &&
-                    waypoints.map(({coordinate, markerComponent: MarkerComponent}) => (
+                    waypoints.map(({coordinate, markerComponent: MarkerComponent}, index) => (
                         <Marker
-                            key={`${coordinate[0]},${coordinate[1]}`}
+                            key={`${index},${coordinate[0]},${coordinate[1]}`}
                             longitude={coordinate[0]}
                             latitude={coordinate[1]}
                         >


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

In the E/App repo, when adding the same location multiple times for a waypoint, we would get the react duplicate keys error. This pr adds a fix for that.

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

GH_LINK

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

When this branch is merged
1. In the E/App repo, go to the component where we use the MapView component
2. Add 2 waypoints that have the same coordinates (use the current location)
3. Verify you don't see the react duplicate keys error

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/25990
